### PR TITLE
Add BIQU SKR, Update MKS SBASE, and Misc

### DIFF
--- a/compileAll.sh
+++ b/compileAll.sh
@@ -1,20 +1,17 @@
 #!/bin/sh
 
 
-BOARDS=("AZTEEGX5MINI" "SMOOTHIEBOARD" "REARM" "AZSMZ" "MKSSBASE")
-NETWORK=("0" "1" "1" "0" "1")
+BOARDS=("AZTEEGX5MINI" "SMOOTHIEBOARD" "REARM" "AZSMZ" "MKSSBASE" "BIQUSKR")
+NETWORK=("0" "1" "1" "0" "1" "0")
 
 
 for i in ${!BOARDS[*]}
 do
   make distclean
-  make firmware BOARD=${BOARDS[$i]} NETWORKING=false OUTPUT_NAME=firmware-${BOARDS[$i]} USE_DFU=false
+  make firmware BOARD=${BOARDS[$i]} NETWORKING=false OUTPUT_NAME=./EdgeRelease/firmware-${BOARDS[$i]} USE_DFU=false
   if [ "${NETWORK[$i]}" = "1" ]
   then
     make distclean
-    make firmware BOARD=${BOARDS[$i]} NETWORKING=true OUTPUT_NAME=firmware-${BOARDS[$i]}-NETWORK USE_DFU=false
+    make firmware BOARD=${BOARDS[$i]} NETWORKING=true OUTPUT_NAME=./EdgeRelease/firmware-${BOARDS[$i]}-NETWORK USE_DFU=false
   fi
-
- 
-
 done

--- a/makefile
+++ b/makefile
@@ -4,9 +4,10 @@ PROCESSOR = LPC17xx
 #BOARD = SMOOTHIEBOARD
 #BOARD = REARM
 #BOARD = AZSMZ
-#BOARD = MKSBASE
+#BOARD = MKSSBASE
+#BOARD = BIQUSKR
 BOARD = MBED
-BUILD_DIR = $(PWD)/build
+BUILD_DIR = ./build
 
 #BUILD = Debug
 BUILD = Release
@@ -205,14 +206,15 @@ RRF_SRC_DIRS += Storage Tools Libraries/Fatfs Libraries/Fatfs/port/lpc Libraries
 RRF_SRC_DIRS += Heating/Sensors Fans ObjectModel
 RRF_SRC_DIRS += LPC LPC/MCP4461
 
-#biuld in LCD Support? only when networking is false
 #networking support?
 ifeq ($(NETWORKING), true)
 	RRF_SRC_DIRS += Networking Networking/RTOSPlusTCPEthernet
 else
 	RRF_SRC_DIRS += LPC/NoNetwork
-	RRF_SRC_DIRS += Display Display/ST7920
 endif
+
+RRF_SRC_DIRS += Display Display/ST7920
+	
 
 #Find the c and cpp source files
 RRF_SRC = $(RRF_SRC_BASE) $(addprefix $(RRF_SRC_BASE)/, $(RRF_SRC_DIRS))


### PR DESCRIPTION
Counterpart to [https://github.com/sdavi/RepRapFirmware/pull/1](https://github.com/sdavi/RepRapFirmware/pull/1)
Add support for the BIQU SKR V1.1
Remove the display dependency with having networking disabled.
Have compileAll.sh output to the EdgeRelease directory by default.