### PR TITLE
Support for building under Visual Studio Code.

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,54 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+      {
+        "label": "build firmware",
+        "type": "shell",
+        "command": "make all",
+        "options": {
+          "env": {
+            "INCLUDE": "${config:arm-none-eabi.include}",
+            "LIB": "${config:arm-none-eabi.lib}",
+            "LIBGCC": "${config:arm-none-eabi.libgcc}/thumb/v6-m/libgcc.a",
+          }
+        },
+        "osx": {
+          "options": {
+            "env": {
+              "PATH": "${config:arm-none-eabi.bin}:${env:PATH}",
+            }
+          },
+        },
+        "linux": {
+          "options": {
+            "env": {
+              "PATH": "${config:arm-none-eabi.bin}:${env:PATH}",
+            }
+          },
+        },
+        "windows": {
+          "options": {
+            "env": {
+              "PATH": "${config:arm-none-eabi.bin};${env:PATH}",
+            }
+          },
+        },
+        "group": {
+          "kind": "build",
+          "isDefault": true,
+        },
+        "problemMatcher": "$gcc"
+      },
+
+      {
+        "label": "clean firmware",
+        "type": "shell",
+        "command": "make clean distclean",
+        "group": {
+          "kind": "build",
+          "isDefault": true,
+        },
+        "problemMatcher": "$gcc"
+      }
+    ]
+  }

--- a/makefile
+++ b/makefile
@@ -5,7 +5,7 @@ PROCESSOR = LPC17xx
 #and select direct ld script
 #MBED = true
 
-BUILD_DIR = $(PWD)/build
+BUILD_DIR = ./build
 
 #BUILD = Debug
 BUILD = Release
@@ -123,7 +123,7 @@ CXXFLAGS = $(FLAGS) -std=gnu++17  -fno-threadsafe-statics -fno-exceptions -fno-r
 #Core
 CORE_SRC_DIRS  = cores system variants/LPC libraries/WIRE libraries/SDCard libraries/SharedSPI
 CORE_SRC_DIRS += cores/ExploreM3 cores/ExploreM3/ExploreM3_lib cores/arduino cores/smoothie
-CORE_SRC_DIRS += cores/smoothie/USBDevice cores/smoothie/USBDevice/USBDevice cores/smoothie/USBDevice/USBSerial/ cores/smoothie/DFU
+CORE_SRC_DIRS += cores/smoothie/USBDevice cores/smoothie/USBDevice/USBDevice cores/smoothie/USBDevice/USBSerial cores/smoothie/DFU
 CORE_SRC_DIRS += cores/lpcopen/src
 
 CORE_SRC = $(CORE) $(addprefix $(CORE)/, $(CORE_SRC_DIRS))


### PR DESCRIPTION
Added a tasks.json file to add build options for visual studio code.  Visual Studio Code requires the GNU Arm Toolchain extension to be installed (windows-arm-none-eabi, linux-arm-non-eabi, or darwin-arm-none-eabi) to build .

I tweaked the build file to fix a couple of build errors when using visual studio code under windows.  The $(PWD) doesn't resolve under windows builds and the forward slash in USBSerial/ was throwing off the linker.